### PR TITLE
Update cmd_debug.c

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -51,7 +51,7 @@ static const char *help_msg_db[] = {
 	"dbj", "", "List breakpoints in JSON format",
 	// "dbi", " 0x848 ecx=3", "stop execution when condition matches",
 	"dbc", " <addr> <cmd>", "Run command when breakpoint is hit",
-	"dbC", " <addr> <cmd>", "Set breakpoint condition on command",
+	"dbC", " <addr> <cmd>", "Run command when breakpoint is hit, but continue until condition on command returns zero",
 	"dbd", " <addr>", "Disable breakpoint",
 	"dbe", " <addr>", "Enable breakpoint",
 	"dbs", " <addr>", "Toggle breakpoint",


### PR DESCRIPTION
Updated help description on `dbC` to show `Run command when breakpoint is hit, but continue until condition on command returns zero`